### PR TITLE
Make CommandHandler instantiated rather than a mix of instance and static fields.

### DIFF
--- a/src/main/java/com/github/hehe3301/CliTestRunner.java
+++ b/src/main/java/com/github/hehe3301/CliTestRunner.java
@@ -4,6 +4,7 @@ import com.github.hehe3301.bot.CommandHandler;
 import com.github.hehe3301.test.MockDiscordClient;
 import com.github.hehe3301.test.MockMessage;
 
+import com.github.hehe3301.time_handler.TimeHandler;
 import sx.blah.discord.api.IDiscordClient;
 import sx.blah.discord.handle.impl.events.guild.channel.message.MessageReceivedEvent;
 import sx.blah.discord.handle.obj.IMessage;
@@ -13,7 +14,8 @@ import java.util.Scanner;
 public class CliTestRunner {
     public static void main(String[] args) {
         Scanner in = new Scanner(System.in);
-        CommandHandler mockBot = new CommandHandler();
+        TimeHandler th = new TimeHandler();
+        CommandHandler mockBot = new CommandHandler(th);
 
         IDiscordClient client = new MockDiscordClient();
         client.getDispatcher().registerListener(mockBot);

--- a/src/main/java/com/github/hehe3301/CliTestRunner.java
+++ b/src/main/java/com/github/hehe3301/CliTestRunner.java
@@ -1,6 +1,7 @@
 package com.github.hehe3301;
 
 import com.github.hehe3301.bot.CommandHandler;
+import com.github.hehe3301.configs.Settings;
 import com.github.hehe3301.test.MockDiscordClient;
 import com.github.hehe3301.test.MockMessage;
 
@@ -11,11 +12,16 @@ import sx.blah.discord.handle.obj.IMessage;
 
 import java.util.Scanner;
 
-public class CliTestRunner {
-    public static void main(String[] args) {
+public class CliTestRunner
+{
+    private final static boolean DEBUG = true;
+
+    public static void main(String[] args)
+    {
+        String prefix = Settings.com_prefix;
         Scanner in = new Scanner(System.in);
         TimeHandler th = new TimeHandler();
-        CommandHandler mockBot = new CommandHandler(th);
+        CommandHandler mockBot = new CommandHandler(prefix, th, DEBUG);
 
         IDiscordClient client = new MockDiscordClient();
         client.getDispatcher().registerListener(mockBot);

--- a/src/main/java/com/github/hehe3301/MainRunner.java
+++ b/src/main/java/com/github/hehe3301/MainRunner.java
@@ -3,10 +3,13 @@ package com.github.hehe3301;
 import com.github.hehe3301.bot.BotUtils;
 import com.github.hehe3301.bot.CommandHandler;
 import com.github.hehe3301.configs.Secrets;
+import com.github.hehe3301.configs.Settings;
 import com.github.hehe3301.time_handler.TimeHandler;
 import sx.blah.discord.api.IDiscordClient;
 
 public class MainRunner {
+
+    private final static boolean DEBUG = true;
 
     public static void main(String[] args){
 
@@ -21,8 +24,9 @@ public class MainRunner {
         IDiscordClient cli = BotUtils.getBuiltDiscordClient(authToken);
 
         // Register a listener via the EventSubscriber annotation which allows for organisation and delegation of events
+        String prefix = Settings.com_prefix;
         TimeHandler th = new TimeHandler();
-        CommandHandler ch = new CommandHandler(th);
+        CommandHandler ch = new CommandHandler(prefix, th, DEBUG);
         cli.getDispatcher().registerListener(ch);
 
         // Only login after all events are registered otherwise some may be missed.

--- a/src/main/java/com/github/hehe3301/MainRunner.java
+++ b/src/main/java/com/github/hehe3301/MainRunner.java
@@ -3,32 +3,30 @@ package com.github.hehe3301;
 import com.github.hehe3301.bot.BotUtils;
 import com.github.hehe3301.bot.CommandHandler;
 import com.github.hehe3301.configs.Secrets;
+import com.github.hehe3301.time_handler.TimeHandler;
 import sx.blah.discord.api.IDiscordClient;
 
 public class MainRunner {
 
     public static void main(String[] args){
 
-        if(args.length != 1){
+        String authToken;
+        if(args.length != 1) {
             System.out.println("Please enter the bots token as the first argument e.g java -jar thisjar.jar tokenhere");
-            IDiscordClient cli = BotUtils.getBuiltDiscordClient(Secrets.getInstance().BOT_TOKEN);
-
-            // Register a listener via the EventSubscriber annotation which allows for organisation and delegation of events
-            cli.getDispatcher().registerListener(new CommandHandler());
-
-            // Only login after all events are registered otherwise some may be missed.
-            cli.login();
-            return;
+            authToken = Secrets.BOT_TOKEN;
+        } else {
+            authToken = args[0];
         }
 
-        IDiscordClient cli = BotUtils.getBuiltDiscordClient(args[0]);
+        IDiscordClient cli = BotUtils.getBuiltDiscordClient(authToken);
 
         // Register a listener via the EventSubscriber annotation which allows for organisation and delegation of events
-        cli.getDispatcher().registerListener(new CommandHandler());
+        TimeHandler th = new TimeHandler();
+        CommandHandler ch = new CommandHandler(th);
+        cli.getDispatcher().registerListener(ch);
 
         // Only login after all events are registered otherwise some may be missed.
         cli.login();
-
     }
 
 }

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -82,6 +82,7 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
         });
     }
 
+    @Override
     public void handle(MessageReceivedEvent event) {
 
         // Note for error handling, you'll probably want to log failed commands with a logger or sout

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -22,17 +22,16 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
         helpMap = new HashMap<>();
         commandMap = new HashMap<>();
 
-        helpMap.put("now", String.format("%s prints the current time" +
-                        " in all supplied timezones, or in UTC if none" +
-                        " are given.",
+        // Command: now
+        helpMap.put("now", String.format(
+                "%s prints the current time in all supplied timezones," +
+                        " or in UTC if none are given.",
                 prefix + "now"));
         commandMap.put("now", (event, args) -> {
-
             CP.cLog(Settings.debug_enabled,
                     String.format(
                             "User: %s instructed me to get current time.\n",
                             event.getAuthor().getName()));
-
             String reply = nowString(
                     event.getAuthor().mention(),
                     args,
@@ -41,19 +40,19 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
             event.getChannel().sendMessage(reply);
         });
 
-        helpMap.put("help", Settings.com_prefix + "help prints this help message.");
+        // Command: help
+        helpMap.put("help", String.format(
+                "%s prints this help message.",
+                prefix + "help"));
         commandMap.put("help", (event, args) -> {
-
-            CP.cLog(Settings.debug_enabled, "User: " + event.getAuthor().getName() + " printed the help.\n");
-
-            StringBuilder printString = new StringBuilder("Commands I know:");
-            for (String key : commandMap.keySet()) {
-                printString.append(String.format(
-                        "\n%s: %s", key, helpMap.get(key)
-                ));
-            }
-            event.getChannel().sendMessage(event.getAuthor().mention() + "\n" + printString);
-
+            CP.cLog(Settings.debug_enabled,
+                    String.format(
+                            "User: %s printed the help.\n",
+                            event.getAuthor().getName()));
+            String reply = helpString(
+                    event.getAuthor().mention(),
+                    helpMap);
+            event.getChannel().sendMessage(reply);
         });
 
         helpMap.put("alias", Settings.com_prefix + "alias adds a alias to a timezone(s), standard is required but daylight savings is optional. ex: alias Eastern EST EDT" + " UNIMPLEMENTED");
@@ -142,5 +141,22 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
         }
 
         return authorMention + "\n" + nowOutput;
+    }
+
+    /**
+     * Concatenate all the help text into a multi-line string.
+     * @param authorMention The user's @mention code.
+     * @param helpMap The helpMap object.
+     * @return The help reply string.
+     */
+    private static String helpString(
+            String authorMention,
+            Map<String, String> helpMap) {
+        String helpText = helpMap.entrySet().stream()
+                .map(entry -> String.format("%s: %s",
+                        entry.getKey(),
+                        entry.getValue()))
+                .collect(Collectors.joining("\n"));
+        return authorMention + "\nCommands I Know:\n" + helpText;
     }
 }

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -15,7 +15,6 @@ public class CommandHandler {
     private Map<String, Command> commandMap;
     private Map<String, String> helpMap;
 
-    public CommandHandler() { this(new TimeHandler()); }
     public CommandHandler(TimeHandler time_handler) {
         helpMap = new HashMap<>();
         commandMap = new HashMap<>();

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -55,18 +55,28 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
             event.getChannel().sendMessage(reply);
         });
 
-        helpMap.put("alias", Settings.com_prefix + "alias adds a alias to a timezone(s), standard is required but daylight savings is optional. ex: alias Eastern EST EDT" + " UNIMPLEMENTED");
+        // Command: alias
+        helpMap.put("alias", String.format(
+                "%1$s adds an alias for a timezone, and optionally its" +
+                        " daylight savings version." +
+                        " ex: %1$s Eastern EST EDT" +
+                        " (UNIMPLEMENTED)",
+                prefix + "alias"));
         commandMap.put("alias", (event, args) -> {
             //TODO implement
-            event.getChannel().sendMessage(event.getAuthor().mention() + "\n" + "This feature has not been implemented yet!");
-
+            String reply = event.getAuthor().mention() + "\n"
+                    + "This feature has not been implemented yet!";
+            event.getChannel().sendMessage(reply);
         });
-        helpMap.put("aliases", Settings.com_prefix + "aliases prints the list of known aliases");
+
+        // Command: aliases
+        helpMap.put("aliases", String.format(
+                "%s prints the list of known aliases",
+                prefix + "aliases"));
         commandMap.put("aliases", (event, args) -> {
-            String printString = time_handler.getAliases();
-
-            event.getChannel().sendMessage(event.getAuthor().mention() + "\n" + printString);
-
+            String reply = event.getAuthor().mention() + "\n"
+                    + time_handler.getAliases();
+            event.getChannel().sendMessage(reply);
         });
 
         helpMap.put("time", Settings.com_prefix + "time translates a time from one timezone to another. ex: time 7pm est utc" + " UNIMPLEMENTED");

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -13,11 +13,17 @@ import java.util.stream.Collectors;
 public class CommandHandler implements IListener<MessageReceivedEvent>
 {
     // A static map of commands mapping from command string to the functional impl
-    private interface Command extends BiConsumer<MessageReceivedEvent, List<String>> {}
+    private interface Command
+            extends BiConsumer<MessageReceivedEvent, List<String>> {}
     private Map<String, Command> commandMap;
     private Map<String, String> helpMap;
 
-    public CommandHandler(TimeHandler time_handler) {
+    /**
+     * A utility object that parses and executes chat commands.
+     * @param time_handler The TimeHandler utility object.
+     */
+    public CommandHandler(TimeHandler time_handler)
+    {
         String prefix = Settings.com_prefix; //TODO: pass as parameter
         helpMap = new HashMap<>();
         commandMap = new HashMap<>();
@@ -35,8 +41,7 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
             String reply = nowString(
                     event.getAuthor().mention(),
                     args,
-                    time_handler
-            );
+                    time_handler);
             event.getChannel().sendMessage(reply);
         });
 
@@ -130,7 +135,8 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
         argsList.remove(0); // Remove the command
 
         // Instead of delegating the work to a switch, automatically do it via calling the mapping if it exists
-        if(!commandMap.containsKey(commandStr)) return;
+        if(!commandMap.containsKey(commandStr))
+            return;
 
         commandMap.get(commandStr).accept(event, argsList);
     }
@@ -146,8 +152,8 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
     private static String nowString(
             String authorMention,
             Collection<String> timeZones,
-            TimeHandler timeHandler) {
-
+            TimeHandler timeHandler)
+    {
         String nowOutput;
         if (timeZones.isEmpty()) {
             nowOutput = timeHandler.now();
@@ -156,7 +162,6 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
                     .map(timeHandler::now)
                     .collect(Collectors.joining("\n"));
         }
-
         return authorMention + "\n" + nowOutput;
     }
 
@@ -168,7 +173,8 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
      */
     private static String helpString(
             String authorMention,
-            Map<String, String> helpMap) {
+            Map<String, String> helpMap)
+    {
         String helpText = helpMap.entrySet().stream()
                 .map(entry -> String.format("%s: %s",
                         entry.getKey(),

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -1,6 +1,5 @@
 package com.github.hehe3301.bot;
 
-import com.github.hehe3301.configs.Settings;
 import com.github.hehe3301.conditional_print.CP;
 import com.github.hehe3301.time_handler.TimeHandler;
 import sx.blah.discord.api.events.IListener;
@@ -17,16 +16,22 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
             extends BiConsumer<MessageReceivedEvent, List<String>> {}
     private Map<String, Command> commandMap;
     private Map<String, String> helpMap;
+    private String prefix;
 
     /**
      * A utility object that parses and executes chat commands.
-     * @param time_handler The TimeHandler utility object.
+     * @param prefix The prefix for commands, as in !command.
+     * @param timeHandler The TimeHandler utility object.
+     * @param debugEnabled Whether or not to log debug messages.
      */
-    public CommandHandler(TimeHandler time_handler)
+    public CommandHandler(
+            String prefix,
+            TimeHandler timeHandler,
+            boolean debugEnabled)
     {
-        String prefix = Settings.com_prefix; //TODO: pass as parameter
-        helpMap = new HashMap<>();
-        commandMap = new HashMap<>();
+        this.helpMap = new HashMap<>();
+        this.commandMap = new HashMap<>();
+        this.prefix = prefix;
 
         // Command: now
         helpMap.put("now", String.format(
@@ -34,14 +39,13 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
                         " or in UTC if none are given.",
                 prefix + "now"));
         commandMap.put("now", (event, args) -> {
-            CP.cLog(Settings.debug_enabled,
-                    String.format(
-                            "User: %s instructed me to get current time.\n",
-                            event.getAuthor().getName()));
+            CP.cLog(debugEnabled, String.format(
+                    "User: %s instructed me to get current time.\n",
+                    event.getAuthor().getName()));
             String reply = nowString(
                     event.getAuthor().mention(),
                     args,
-                    time_handler);
+                    timeHandler);
             event.getChannel().sendMessage(reply);
         });
 
@@ -50,10 +54,9 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
                 "%s prints this help message.",
                 prefix + "help"));
         commandMap.put("help", (event, args) -> {
-            CP.cLog(Settings.debug_enabled,
-                    String.format(
-                            "User: %s printed the help.\n",
-                            event.getAuthor().getName()));
+            CP.cLog(debugEnabled, String.format(
+                    "User: %s printed the help.\n",
+                    event.getAuthor().getName()));
             String reply = helpString(
                     event.getAuthor().mention(),
                     helpMap);
@@ -80,7 +83,7 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
                 prefix + "aliases"));
         commandMap.put("aliases", (event, args) -> {
             String reply = event.getAuthor().mention() + "\n"
-                    + time_handler.getAliases();
+                    + timeHandler.getAliases();
             event.getChannel().sendMessage(reply);
         });
 
@@ -103,7 +106,7 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
                 prefix + "zones"));
         commandMap.put("zones", (event, args) -> {
             String reply = event.getAuthor().mention() + "\n"
-                    + time_handler.dumpZones();
+                    + timeHandler.dumpZones();
             event.getChannel().sendMessage(reply);
         });
     }
@@ -124,11 +127,11 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
             return;
 
         // Check if the first arg (the command) starts with the prefix defined in the utils class
-        if(!argArray[0].startsWith(Settings.com_prefix))
+        if(!argArray[0].startsWith(prefix))
             return;
 
         // Extract the "command" part of the first arg out by ditching the amount of characters present in the prefix
-        String commandStr = argArray[0].substring(Settings.com_prefix.length());
+        String commandStr = argArray[0].substring(prefix.length());
 
         // Load the rest of the args in the array into a List for safer access
         List<String> argsList = new ArrayList<>(Arrays.asList(argArray));

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -12,11 +12,14 @@ import java.util.function.BiConsumer;
 public class CommandHandler {
     // A static map of commands mapping from command string to the functional impl
     private interface Command extends BiConsumer<MessageReceivedEvent, List<String>> {}
-    private static Map<String, Command> commandMap = new HashMap<>();
-    private static Map<String, String> helpMap = new HashMap<>();
+    private Map<String, Command> commandMap;
+    private Map<String, String> helpMap;
 
-    public CommandHandler() {
-        TimeHandler time_handler = new TimeHandler();
+    public CommandHandler() { this(new TimeHandler()); }
+    public CommandHandler(TimeHandler time_handler) {
+        helpMap = new HashMap<>();
+        commandMap = new HashMap<>();
+
         helpMap.put("now", Settings.com_prefix + "now prints the current time in UTC if not called with a parameter, or in the given TZ's if they exists.");
         commandMap.put("now", (event, args) -> {
 

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -92,12 +92,14 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
             event.getChannel().sendMessage(reply);
         });
 
-        helpMap.put("zones",Settings.com_prefix+"zones dumps all the known time zones!");
+        // Command: zones
+        helpMap.put("zones", String.format(
+                "%s lists all the known time zones.",
+                prefix + "zones"));
         commandMap.put("zones", (event, args) -> {
-
-            String printString = time_handler.dumpZones();
-            event.getChannel().sendMessage(event.getAuthor().mention()+"\n"+printString);
-
+            String reply = event.getAuthor().mention() + "\n"
+                    + time_handler.dumpZones();
+            event.getChannel().sendMessage(reply);
         });
     }
 

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -27,8 +27,13 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
                         " are given.",
                 prefix + "now"));
         commandMap.put("now", (event, args) -> {
+
+            CP.cLog(Settings.debug_enabled,
+                    String.format(
+                            "User: %s instructed me to get current time.\n",
+                            event.getAuthor().getName()));
+
             String reply = nowString(
-                    event.getAuthor().getName(),
                     event.getAuthor().mention(),
                     args,
                     time_handler
@@ -117,22 +122,15 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
     /**
      * Reply with the current time in all supplied timezones, or in
      * UTC by default.
-     * @param authorName The user who requested the time.
      * @param authorMention The user's @mention code.
      * @param timeZones The set of time zones to check.
      * @param timeHandler The timezone utility object.
      * @return A formatted reply string.
      */
     private static String nowString(
-            String authorName,
             String authorMention,
             Collection<String> timeZones,
             TimeHandler timeHandler) {
-
-        CP.cLog(Settings.debug_enabled,
-                String.format(
-                        "User: %s instructed me to get current time.\n",
-                        authorName));
 
         String nowOutput;
         if (timeZones.isEmpty()) {

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -28,9 +28,11 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
             if (args.isEmpty()) {
                 rtn = "\n" + time_handler.now();
             } else {
+                StringBuilder tempStr = new StringBuilder(rtn);
                 for (String tz : args) {
-                    rtn = rtn + "\n" + time_handler.now(tz);
+                    tempStr.append("\n").append(time_handler.now(tz));
                 }
+                rtn = tempStr.toString();
             }
 
             event.getChannel().sendMessage(event.getAuthor().mention() + rtn);
@@ -43,9 +45,11 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
 
             CP.cLog(Settings.debug_enabled, "User: " + event.getAuthor().getName() + " printed the help.\n");
 
-            String printString = "Commands I know:";
+            StringBuilder printString = new StringBuilder("Commands I know:");
             for (String key : commandMap.keySet()) {
-                printString = printString + "\n" + key + ": " + helpMap.get(key);
+                printString.append(String.format(
+                        "\n%s: %s", key, helpMap.get(key)
+                ));
             }
             event.getChannel().sendMessage(event.getAuthor().mention() + "\n" + printString);
 

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -79,12 +79,17 @@ public class CommandHandler implements IListener<MessageReceivedEvent>
             event.getChannel().sendMessage(reply);
         });
 
-        helpMap.put("time", Settings.com_prefix + "time translates a time from one timezone to another. ex: time 7pm est utc" + " UNIMPLEMENTED");
+        // Command: time
+        // TODO: Consider renaming this one? -nupa
+        helpMap.put("time", String.format(
+                "%s translates a time from one timezone to another. " +
+                        "ex: %1$s 7pm est utc (UNIMPLEMENTED)",
+                prefix + "time"));
         commandMap.put("time", (event, args) -> {
-
             //TODO implement
-            event.getChannel().sendMessage(event.getAuthor().mention() + "\n" + "This feature has not been implemented yet!");
-
+            String reply = event.getAuthor().mention() + "\n"
+                    + "This feature has not been implemented yet!";
+            event.getChannel().sendMessage(reply);
         });
 
         helpMap.put("zones",Settings.com_prefix+"zones dumps all the known time zones!");

--- a/src/main/java/com/github/hehe3301/bot/CommandHandler.java
+++ b/src/main/java/com/github/hehe3301/bot/CommandHandler.java
@@ -3,13 +3,14 @@ package com.github.hehe3301.bot;
 import com.github.hehe3301.configs.Settings;
 import com.github.hehe3301.conditional_print.CP;
 import com.github.hehe3301.time_handler.TimeHandler;
-import sx.blah.discord.api.events.EventSubscriber;
+import sx.blah.discord.api.events.IListener;
 import sx.blah.discord.handle.impl.events.guild.channel.message.MessageReceivedEvent;
 
 import java.util.*;
 import java.util.function.BiConsumer;
 
-public class CommandHandler {
+public class CommandHandler implements IListener<MessageReceivedEvent>
+{
     // A static map of commands mapping from command string to the functional impl
     private interface Command extends BiConsumer<MessageReceivedEvent, List<String>> {}
     private Map<String, Command> commandMap;
@@ -81,8 +82,7 @@ public class CommandHandler {
         });
     }
 
-    @EventSubscriber
-    public void onMessageReceived(MessageReceivedEvent event) {
+    public void handle(MessageReceivedEvent event) {
 
         // Note for error handling, you'll probably want to log failed commands with a logger or sout
         // In most cases it's not advised to annoy the user with a reply incase they didn't intend to trigger a


### PR DESCRIPTION
Removes class-level variables in CommandHandler, and access global Settings from the calling context rather than from inside CommandHandler. Still has global access to CP, but that's a logging framework so that's fine.